### PR TITLE
Update the players inventory after cancelling the transaction from recipe books

### DIFF
--- a/NoDroppingOffline/src/main/java/com/minetexas/nodroppingoffline/NoDroppingOffline.java
+++ b/NoDroppingOffline/src/main/java/com/minetexas/nodroppingoffline/NoDroppingOffline.java
@@ -31,6 +31,9 @@ public class NoDroppingOffline extends JavaPlugin {
 	    		        if (event.getPacketType() == 
 	    		                PacketType.Play.Client.AUTO_RECIPE ) {
 	    		            event.setCancelled(true);
+                                    // Instead of sending a transaction packet, we can do this instead!
+                                    // (I couldn't get sending a transaction packet with false, this this will have to do :( )
+                                    event.getPlayer().updateInventory();
 	    		        }
 	    		    }
 	    		});


### PR DESCRIPTION
Sending the transaction packet with false as the status apparently decided to it was not going to be nice to me, so... this is the alternative...